### PR TITLE
fix typo

### DIFF
--- a/lib/bitfinex/wallet.rb
+++ b/lib/bitfinex/wallet.rb
@@ -19,9 +19,9 @@ module Bitfinex
     # 
     # @return [Array]
     # @example: 
-    #   client.margin_info
-    def margin_info
-      authenticated_post("margin_info").body
+    #   client.margin_infos
+    def margin_infos
+      authenticated_post("margin_infos").body
     end
 
     # Allow you to move available balances between your wallets.

--- a/spec/bitfinex/wallet_spec.rb
+++ b/spec/bitfinex/wallet_spec.rb
@@ -14,10 +14,10 @@ describe Bitfinex::Client do
     it {expect(@response.size).to eq(1)}
   end
 
-  context "margin_info" do
+  context "margin_infos" do
     before do 
-      stub_http("/margin_info", response.to_json, method: :post)
-      @response = client.margin_info
+      stub_http("/margin_infos", response.to_json, method: :post)
+      @response = client.margin_infos
     end
 
     it {expect(@response.size).to eq(1)}


### PR DESCRIPTION
this fix a typo, it was calling the wrong endpoint `/margin_info instead` of `/margin_infos`