### PR TITLE
Fixed similar issue with history calls silently dropping params

### DIFF
--- a/lib/bitfinex/historical_data.rb
+++ b/lib/bitfinex/historical_data.rb
@@ -2,7 +2,7 @@ module Bitfinex
   module HistoricalDataClient
 
     # View all of your balance ledger entries.
-    # 
+    #
     # @param currency [string] (optional) Specify the currency, default "USD"
     # @param params :since [time] (optional) Return only the history after this timestamp.
     # @param params :until [time] (optional) Return only the history before this timestamp.
@@ -12,13 +12,13 @@ module Bitfinex
     # @example:
     #   client.history
     def history(currency="usd", params = {})
-      check_params(params, %i{since until limit wallet}) 
+      check_params(params, %i{since until limit wallet})
       params.merge!({currency: currency})
-      authenticated_post("history", params).body
+      authenticated_post("history", params: params).body
     end
 
     # View your past deposits/withdrawals.
-    # 
+    #
     # @param currency [string] (optional) Specify the currency, default "USD"
     # @param params :method (optional) The method of the deposit/withdrawal (can be “bitcoin”, “litecoin”, “darkcoin”, “wire”)
     # @param params :since (optional) Return only the history after this timestamp
@@ -30,11 +30,11 @@ module Bitfinex
     def movements(currency="usd", params = {})
       check_params(params, %i{method since until limit})
       params.merge!({currency: currency})
-      authenticated_post("history/movements", params).body
+      authenticated_post("history/movements", params: params).body
     end
 
     # View your past trades.
-    # 
+    #
     # @param symbol The pair traded (BTCUSD, LTCUSD, LTCBTC)
     # @param params :until [time] (optional) Return only the history before this timestamp.
     # @param params :timestamp [time] (optional) Trades made before this timestamp won’t be returned
@@ -47,7 +47,7 @@ module Bitfinex
     def mytrades(symbol, params = {})
       check_params(params, %i{until limit_trades reverse timestamp})
       params.merge!({symbol: symbol})
-      authenticated_post("mytrades", params).body
+      authenticated_post("mytrades", params: params).body
     end
   end
 end


### PR DESCRIPTION
Probably makes sense to check that all authenticated_post(...) calls are passing params properly...