### PR TITLE
force types and remove trailing spaces

### DIFF
--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'faraday', '~> 0.9.2', '>= 0.9.2'
-  spec.add_runtime_dependency 'eventmachine', '~> 1.0.9.1'
+  spec.add_runtime_dependency 'eventmachine', '~> 1.0', '>= 1.0.9.1'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 1.0.0', '>= 1.0.0'
   spec.add_runtime_dependency 'faye-websocket', '~> 0.10.3'
   spec.add_runtime_dependency 'json', '~> 1.8.3','>= 1.8.3'

--- a/lib/bitfinex/account_info.rb
+++ b/lib/bitfinex/account_info.rb
@@ -1,7 +1,7 @@
 module Bitfinex
 
-  module AccountInfoClient 
-    
+  module AccountInfoClient
+
     # Get account information
     #
     # @return [Hash] your account information

--- a/lib/bitfinex/configurable.rb
+++ b/lib/bitfinex/configurable.rb
@@ -3,7 +3,7 @@ module Bitfinex
     def self.included(base)
       base.extend(ClassMethods)
     end
-  
+
     def config
       self.class.config
     end

--- a/lib/bitfinex/connection.rb
+++ b/lib/bitfinex/connection.rb
@@ -2,7 +2,7 @@ require 'logger'
 module Bitfinex
   # Network Layer for API Rest client
   module RestConnection
-    private 
+    private
     # Make an HTTP GET request
     def get(url, options={})
       rest_connection.get do |req|

--- a/lib/bitfinex/deposit.rb
+++ b/lib/bitfinex/deposit.rb
@@ -1,7 +1,7 @@
 module Bitfinex
   module DepositClient
     # Return your deposit address to make a new deposit.
-    # 
+    #
     # @param method [string] Method of deposit (methods accepted: “bitcoin”, “litecoin”, “darkcoin”, “mastercoin” (tethers)).
     # @param wallet_name [string] Wallet to deposit in (accepted: “trading”, “exchange”, “deposit”). Your wallet needs to already exist
     # @params renew [integer] (optional) Default is 0. If set to 1, will return a new unused deposit address
@@ -11,8 +11,8 @@ module Bitfinex
     #   client.deposit("bitcoin", "exchange")
     def deposit method, wallet_name, renew=0
       params = {
-        method: method, 
-        wallet_name: wallet_name, 
+        method: method,
+        wallet_name: wallet_name,
         renew: renew
       }
 

--- a/lib/bitfinex/funding_book.rb
+++ b/lib/bitfinex/funding_book.rb
@@ -6,9 +6,9 @@ module Bitfinex
     # @param currency [string] (optional) Speficy the currency, default "USD"
     # @param params :limit_bids [int] (optional) Limit the number of funding bids returned. May be 0 in which case the array of bids is empty.
     # @param params :limit_asks [int] (optional) Limit the number of funding offers returned. May be 0 in which case the array of asks is empty.
-    # @return [Hash] of :bids and :asks arrays 
+    # @return [Hash] of :bids and :asks arrays
     # @example:
-    #   client.funding_book 
+    #   client.funding_book
     def funding_book(currency="usd", params = {})
       check_params(params, %i{limit_bids limit_asks})
       get("lendbook/#{currency}", params).body

--- a/lib/bitfinex/historical_data.rb
+++ b/lib/bitfinex/historical_data.rb
@@ -2,7 +2,7 @@ module Bitfinex
   module HistoricalDataClient
 
     # View all of your balance ledger entries.
-    # 
+    #
     # @param currency [string] (optional) Specify the currency, default "USD"
     # @param params :since [time] (optional) Return only the history after this timestamp.
     # @param params :until [time] (optional) Return only the history before this timestamp.
@@ -12,13 +12,13 @@ module Bitfinex
     # @example:
     #   client.history
     def history(currency="usd", params = {})
-      check_params(params, %i{since until limit wallet}) 
+      check_params(params, %i{since until limit wallet})
       params.merge!({currency: currency})
       authenticated_post("history", params).body
     end
 
     # View your past deposits/withdrawals.
-    # 
+    #
     # @param currency [string] (optional) Specify the currency, default "USD"
     # @param params :method (optional) The method of the deposit/withdrawal (can be “bitcoin”, “litecoin”, “darkcoin”, “wire”)
     # @param params :since (optional) Return only the history after this timestamp
@@ -34,7 +34,7 @@ module Bitfinex
     end
 
     # View your past trades.
-    # 
+    #
     # @param symbol The pair traded (BTCUSD, LTCUSD, LTCBTC)
     # @param params :until [time] (optional) Return only the history before this timestamp.
     # @param params :timestamp [time] (optional) Trades made before this timestamp won’t be returned

--- a/lib/bitfinex/lends.rb
+++ b/lib/bitfinex/lends.rb
@@ -1,9 +1,9 @@
 module Bitfinex
-  module LendsClient 
+  module LendsClient
 
     # Get a list of the most recent funding data for the given currency: total amount provided and Flash Return Rate (in % by 365 days) over time.
     #
-    # @param currency [string] (optional) Specify the currency, default "USD" 
+    # @param currency [string] (optional) Specify the currency, default "USD"
     # @param params :timestamp [time] (optional) Only show data at or after this timestamp
     # @param params :limit_lends [int] (optional) Limit the amount of funding data returned. Must be > 1, default 50
     # @return [Array]

--- a/lib/bitfinex/orders.rb
+++ b/lib/bitfinex/orders.rb
@@ -11,27 +11,28 @@ module Bitfinex
     # @param params :is_hidden [bool] (optional) true if the order should be hidden. Default is false
     # @param params :is_postonly [bool] (optional) true if the order should be post only. Default is false. Only relevant for limit orders
     # @param params :ocoorder [bool] Set an additional STOP OCO order that will be linked with the current order
-    # @param params :buy_price_oco [decimal] If ocoorder is true, this field represent the price of the OCO stop order to place 
+    # @param params :buy_price_oco [decimal] If ocoorder is true, this field represent the price of the OCO stop order to place
     # @return [Hash]
     # @example:
-    #   client.new_order("usdbtc", 100, "market", "sell", 0)    
-    def new_order(symbol, amount, type, side, price = nil, params = {}) 
+    #   client.new_order("usdbtc", 100, "market", "sell", 0)
+    def new_order(symbol, amount, type, side, price = nil, params = {})
       check_params(params, %i{is_hidden is_postonly ocoorder buy_price_oco})
 
       params.merge!({
-        symbol: symbol, 
-        amount: amount,
+        symbol: symbol,
+        amount: amount.to_s,
         type: type,
         side: side,
         exchange: 'bitfinex',
-        price: price})
+        price: price.to_s
+      })
 
       authenticated_post("order/new", params: params).body
     end
 
     # Submit several new orders at once
     #
-    # @param orders [Array] Array of Hash with the following elements 
+    # @param orders [Array] Array of Hash with the following elements
     # @param orders :symbol [string] The name of the symbol
     # @param orders :amount [decimal] Order size: how much to buy or sell
     # @param orders :price [decimal] Price to buy or sell at. May omit if a market order
@@ -47,7 +48,7 @@ module Bitfinex
 
     # Cancel an order
     #
-    # @param ids [Array] or [integer] or nil 
+    # @param ids [Array] or [integer] or nil
     #   if it's Array it's supposed to specify a list of IDS
     #   if it's an integer it's supposed to be a single ID
     #   if it's not specified it deletes all the orders placed
@@ -56,7 +57,7 @@ module Bitfinex
     #   client.cancel_orders([100,231,400])
     def cancel_orders(ids=nil)
       case ids
-      when Array 
+      when Array
           authenticated_post("order/cancel/multi", {order_ids: ids}).body
       when Numeric
           authenticated_post("order/cancel", {order_id: ids}).body
@@ -68,27 +69,27 @@ module Bitfinex
     end
 
     # Replace an orders with a new one
-    # 
+    #
     # @param id [int] the ID of the order to replace
     # @param symbol [string] the name of the symbol
     # @param amount [decimal] Order size: how much to buy or sell
-    # @param type [string] Either “market” / “limit” / “stop” / “trailing-stop” / “fill-or-kill” / “exchange market” / “exchange limit” / “exchange stop” / “exchange trailing-stop” / “exchange fill-or-kill”. (type starting by “exchange ” are exchange orders, others are margin trading orders)  
+    # @param type [string] Either “market” / “limit” / “stop” / “trailing-stop” / “fill-or-kill” / “exchange market” / “exchange limit” / “exchange stop” / “exchange trailing-stop” / “exchange fill-or-kill”. (type starting by “exchange ” are exchange orders, others are margin trading orders)
     # @param side [string] Either “buy” or “sell”
     # @param price [decimal] Price to buy or sell at. May omit if a market order
     # @param is_hidden [bool] (optional) true if the order should be hidden. Default is false
     # @return [Hash] the order
-    # @example: 
+    # @example:
     #   client.replace_order(100,"usdbtc", 10, "market", "buy", 0)
     def replace_order(id, symbol, amount, type, side, price, is_hidden=false)
       params = {
-        order_id: id,
-        symbol: symbol, 
-        amount: amount,
+        order_id: id.to_i,
+        symbol: symbol,
+        amount: amount.to_s,
         type: type,
         side: side,
         exchange: 'bitfinex',
         is_hidden: is_hidden,
-        price: price
+        price: price.to_s
       }
       authenticated_post("order/cancel/replace", params).body
     end
@@ -112,6 +113,6 @@ module Bitfinex
     def orders
       authenticated_post("orders").body
     end
-    
+
   end
 end

--- a/lib/bitfinex/version.rb
+++ b/lib/bitfinex/version.rb
@@ -1,3 +1,3 @@
 module Bitfinex
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
This enforce the correct types for the `orders` endpoints. Also cleanup trailing spaces.