### PR TITLE
fix params passing for get requests

### DIFF
--- a/lib/bitfinex/funding_book.rb
+++ b/lib/bitfinex/funding_book.rb
@@ -11,7 +11,7 @@ module Bitfinex
     #   client.funding_book
     def funding_book(currency="usd", params = {})
       check_params(params, %i{limit_bids limit_asks})
-      get("lendbook/#{currency}", params).body
+      get("lendbook/#{currency}", params: params).body
     end
 
   end

--- a/lib/bitfinex/lends.rb
+++ b/lib/bitfinex/lends.rb
@@ -11,7 +11,7 @@ module Bitfinex
     #   client.lends
     def lends(currency = "usd", params = {})
       check_params(params, %i{timestamp limit_lends})
-      get("lends/#{currency}", params).body
+      get("lends/#{currency}", params: params).body
     end
 
   end

--- a/lib/bitfinex/orderbook.rb
+++ b/lib/bitfinex/orderbook.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Bitfinex
   module OrderbookClient
 
@@ -12,7 +13,7 @@ module Bitfinex
     #   client.orderbook("btcusd")
     def orderbook(symbol="btcusd", params = {})
       check_params(params, %i{limit_bids limit_asks group})
-      get("book/#{symbol}",params).body
+      get("book/#{symbol}", params: params).body
     end
 
 


### PR DESCRIPTION
Fix params passing to `get` method not being wrapped to key `params` correctly