### PR TITLE
add configurable timeout to rest connections

### DIFF
--- a/lib/bitfinex/authenticated_rest.rb
+++ b/lib/bitfinex/authenticated_rest.rb
@@ -9,7 +9,7 @@ module Bitfinex
       response = rest_connection.post do |req|
         req.url complete_url
         req.options.timeout = config.rest_timeout
-        req.options.open_timeout = config.rest_timeout
+        req.options.open_timeout = config.rest_open_timeout
         req.headers['Content-Type'] = 'application/json'
         req.headers['Accept'] = 'application/json'
         req.headers['X-BFX-PAYLOAD'] = payload

--- a/lib/bitfinex/authenticated_rest.rb
+++ b/lib/bitfinex/authenticated_rest.rb
@@ -8,11 +8,13 @@ module Bitfinex
       payload = build_payload("/v1/#{url}", options[:params])
       response = rest_connection.post do |req|
         req.url complete_url
+        req.options.timeout = config.rest_timeout
+        req.options.open_timeout = config.rest_timeout
         req.headers['Content-Type'] = 'application/json'
         req.headers['Accept'] = 'application/json'
         req.headers['X-BFX-PAYLOAD'] = payload
         req.headers['X-BFX-SIGNATURE'] = sign(payload)
-        req.headers['X-BFX-APIKEY'] = config.api_key 
+        req.headers['X-BFX-APIKEY'] = config.api_key
       end
     end
 

--- a/lib/bitfinex/configurable.rb
+++ b/lib/bitfinex/configurable.rb
@@ -20,14 +20,14 @@ module Bitfinex
   end
 
   class Configuration
-     attr_accessor :api_endpoint, :debug, :debug_connection, :secret, :api_key, :websocket_api_endpoint
-     def initialize
-       self.api_endpoint = "https://api.bitfinex.com/v1/"
-       self.websocket_api_endpoint = "wss://api2.bitfinex.com:3000/ws"
-       self.debug = false
-
-       self.debug_connection = false
-     end
+    attr_accessor :api_endpoint, :debug, :debug_connection, :secret, :api_key, :websocket_api_endpoint, :rest_timeout
+    def initialize
+      self.api_endpoint = "https://api.bitfinex.com/v1/"
+      self.websocket_api_endpoint = "wss://api2.bitfinex.com:3000/ws"
+      self.debug = false
+      self.rest_timeout = 30
+      self.debug_connection = false
+    end
   end
 
 end

--- a/lib/bitfinex/configurable.rb
+++ b/lib/bitfinex/configurable.rb
@@ -20,12 +20,13 @@ module Bitfinex
   end
 
   class Configuration
-    attr_accessor :api_endpoint, :debug, :debug_connection, :secret, :api_key, :websocket_api_endpoint, :rest_timeout
+    attr_accessor :api_endpoint, :debug, :debug_connection, :secret, :api_key, :websocket_api_endpoint, :rest_timeout, :rest_open_timeout
     def initialize
       self.api_endpoint = "https://api.bitfinex.com/v1/"
       self.websocket_api_endpoint = "wss://api2.bitfinex.com:3000/ws"
       self.debug = false
       self.rest_timeout = 30
+      self.rest_open_timeout = 30
       self.debug_connection = false
     end
   end

--- a/lib/bitfinex/connection.rb
+++ b/lib/bitfinex/connection.rb
@@ -11,7 +11,7 @@ module Bitfinex
         req.headers['Accept'] = 'application/json'
         req.params = options[:params] if options.has_key?(:params) && !options[:params].empty?
         req.options.timeout = config.rest_timeout
-        req.options.open_timeout = config.rest_timeout
+        req.options.open_timeout = config.rest_open_timeout
       end
     end
 

--- a/lib/bitfinex/connection.rb
+++ b/lib/bitfinex/connection.rb
@@ -10,6 +10,8 @@ module Bitfinex
         req.headers['Content-Type'] = 'application/json'
         req.headers['Accept'] = 'application/json'
         req.params = options[:params] if options.has_key?(:params) && !options[:params].empty?
+        req.options.timeout = config.rest_timeout
+        req.options.open_timeout = config.rest_timeout
       end
     end
 

--- a/lib/bitfinex/version.rb
+++ b/lib/bitfinex/version.rb
@@ -1,3 +1,3 @@
 module Bitfinex
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
default timeout is 30 seconds, can be customized in the configuration block, example:

```
Bitfinex::Client.configure do |conf|
  conf.rest_timeout = 60
  conf.rest_open_timeout = 20
end
```