### PR TITLE
allow use_all_available param to create new order

### DIFF
--- a/lib/bitfinex/orders.rb
+++ b/lib/bitfinex/orders.rb
@@ -16,7 +16,7 @@ module Bitfinex
     # @example:
     #   client.new_order("usdbtc", 100, "market", "sell", 0)
     def new_order(symbol, amount, type, side, price = nil, params = {})
-      check_params(params, %i{is_hidden is_postonly ocoorder buy_price_oco})
+      check_params(params, %i{is_hidden is_postonly ocoorder buy_price_oco use_all_available})
 
       # for 'market' order, we need to pass a random positive price, not nil
       price ||= 0.001 if type == "market" || type == "exchange market"


### PR DESCRIPTION
This PR intends to introduce the `use_all_available` parameters into the list of
allowed parameters to create new orders.