### PR TITLE
bump json to 1.8.5

### DIFF
--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine', '~> 1.0', '>= 1.0.9.1'
   spec.add_runtime_dependency 'faraday-detailed_logger', '~> 1.0.0', '>= 1.0.0'
   spec.add_runtime_dependency 'faye-websocket', '~> 0.10.3'
-  spec.add_runtime_dependency 'json', '~> 1.8.3','>= 1.8.3'
+  spec.add_runtime_dependency 'json', '~> 1.8.5', '>= 1.8.5'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.10', '>= 0.10.0'
 end


### PR DESCRIPTION
Ruby 2.4 has an issue with json 1.8.3 used in the gem. This just bumps the json version to 1.8.5

Details of the error are here:

https://github.com/flori/json/issues/303

the Bitfinex-rb gem seems to work fine after the version bump.


