### PR TITLE
fix skipping params for orderbook

### DIFF
--- a/lib/bitfinex/v1/orderbook.rb
+++ b/lib/bitfinex/v1/orderbook.rb
@@ -13,7 +13,7 @@ module Bitfinex
     #   client.orderbook("btcusd")
     def orderbook(symbol="btcusd", params = {})
       check_params(params, %i{limit_bids limit_asks group})
-      get("book/#{symbol}", params: params).body
+      get("book/#{symbol}", params).body
     end
 
 


### PR DESCRIPTION
simple fix for ignoring params by orderbook method

get method takes normal argument instead of keyword one's

[lib/bitfinex/connection.rb:](https://github.com/bitfinexcom/bitfinex-api-rb/blob/master/lib/bitfinex/connection.rb)

```
def get(url, params={})
  ...
 end
```