### PR TITLE
Update websocket_connection.rb

### DIFF
--- a/lib/bitfinex/websocket_connection.rb
+++ b/lib/bitfinex/websocket_connection.rb
@@ -23,7 +23,7 @@ module Bitfinex
 
     def ws_auth(&block)
       unless @ws_auth
-        nonce = (Time.now.to_f * 10_000).to_i.to_s
+        nonce = (Time.now.to_f * 1000000).to_i.to_s
         sub_id = add_callback(&block)
         save_channel_id(sub_id,0)
         if config.api_version == 1


### PR DESCRIPTION
The current nonce does not work on websocket v2. The change will make it work. The timestamp needs to be in nanoseconds.