### PR TITLE
Feature: Order Callbacks & Cancel Order

### DIFF
--- a/examples/ws/v2/orders.rb
+++ b/examples/ws/v2/orders.rb
@@ -3,7 +3,8 @@ require_relative '../../../lib/bitfinex.rb'
 client = Bitfinex::WSv2.new({
   :url => ENV['WS_URL'],
   :api_key => ENV['API_KEY'],
-  :api_secret => ENV['API_SECRET']
+  :api_secret => ENV['API_SECRET'],
+  :transform => true
 })
 
 client.on(:open) do
@@ -20,11 +21,17 @@ client.on(:auth) do
     :symbol => 'tEOSUSD'
   })
 
-  client.submit_order(o)
+  client.submit_order(o) do |order_packet|
+    p "recv order confirmation packet with ID #{order_packet.id}"
+
+    client.cancel_order(order_packet) do |canceled_order|
+      p "canceled order with ID #{canceled_order[0]}"
+    end
+  end
 end
 
 client.on(:notification) do |n|
-  p 'received notification: %s' % [n]
+  p 'received notification: %s' % [n.serialize.join('|')]
 end
 
 client.on(:order_new) do |msg|


### PR DESCRIPTION
This PR adds a `cancel_order` method to WSv2, and support for callbacks in both `cancel_order` and `submit_order` that resolve with received notifications. Example:

```ruby
client = Bitfinex::WSv2.new({
  # ...
  :transform => true
})

client.on(:open) { client.auth! }
client.on(:auth) do
  p 'succesfully authenticated'

  o = Bitfinex::Models::Order.new({
    :type => 'EXCHANGE LIMIT',
    :price => 3.0152235,
    :amount => 2.0235235263262,
    :symbol => 'tEOSUSD'
  })

  client.submit_order(o) do |order_packet|
    p "recv order confirmation packet with ID #{order_packet.id}"

    client.cancel_order(order_packet) do |canceled_order|
      p "canceled order with ID #{canceled_order[0]}"
    end
  end
end
```