### PR TITLE
Refactor: add symbol to funding/trading ticker models

### DIFF
--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bitfinex-rb'
-  spec.version       = '1.0.2'
+  spec.version       = '1.0.3'
   spec.authors       = ['Bitfinex']
   spec.email         = ['developers@bitfinex.com']
   spec.summary       = %q{Bitfinex API Wrapper}

--- a/examples/rest/v2/tickers.rb
+++ b/examples/rest/v2/tickers.rb
@@ -7,4 +7,4 @@ client = Bitfinex::RESTv2.new({
   :api_secret => ENV['API_SECRET']
 })
 
-puts client.ticker('tBTCUSD', 'tETHUSD')
+puts client.ticker('tBTCUSD', 'fUSD')

--- a/examples/ws/v2/ticker.rb
+++ b/examples/ws/v2/ticker.rb
@@ -12,6 +12,7 @@ end
 
 client.on(:open) do
   client.subscribe_ticker('tBTCUSD')
+  client.subscribe_ticker('fUSD')
 end
 
 client.open!

--- a/lib/models/funding_ticker.rb
+++ b/lib/models/funding_ticker.rb
@@ -5,19 +5,20 @@ module Bitfinex
     class FundingTicker < Model
       BOOL_FIELDS = []
       FIELDS = {
-        frr: 0,
-        bid: 1,
-        bid_size: 2,
-        bid_period: 3,
-        ask: 4,
-        ask_size: 5,
-        ask_period: 6,
-        daily_change: 7,
-        daily_change_perc: 8,
-        last_price: 9,
-        volume: 10,
-        high: 11,
-        low: 12
+        symbol: 0,
+        frr: 1,
+        bid: 2,
+        bid_size: 3,
+        bid_period: 4,
+        ask: 5,
+        ask_size: 6,
+        ask_period: 7,
+        daily_change: 8,
+        daily_change_perc: 9,
+        last_price: 10,
+        volume: 11,
+        high: 12,
+        low: 13
       }
 
       FIELDS.each do |key, index|

--- a/lib/models/trading_ticker.rb
+++ b/lib/models/trading_ticker.rb
@@ -5,16 +5,17 @@ module Bitfinex
     class TradingTicker < Model
       BOOL_FIELDS = []
       FIELDS = {
-        bid: 0,
-        bid_size: 1,
-        ask: 2,
-        ask_size: 3,
-        daily_change: 4,
-        daily_change_perc: 5,
-        last_price: 6,
-        volume: 7,
-        high: 8,
-        low: 9
+        symbol: 0,
+        bid: 1,
+        bid_size: 2,
+        ask: 3,
+        ask_size: 4,
+        daily_change: 5,
+        daily_change_perc: 6,
+        last_price: 7,
+        volume: 8,
+        high: 9,
+        low: 10
       }
 
       FIELDS.each do |key, index|

--- a/lib/ws/ws2.rb
+++ b/lib/ws/ws2.rb
@@ -229,11 +229,12 @@ module Bitfinex
 
     def handle_ticker_message (msg, chan) # :nodoc:
       payload = msg[1]
+      payload_with_sym = [chan['symbol']].concat(payload)
 
       if chan['symbol'][0] === 't'
-        emit(:ticker, chan['symbol'], @transform ? Models::TradingTicker.new(payload) : payload)
+        emit(:ticker, chan['symbol'], @transform ? Models::TradingTicker.new(payload_with_sym) : payload)
       else
-        emit(:ticker, chan['symbol'], @transform ? Models::FundingTicker.new(payload) : payload)
+        emit(:ticker, chan['symbol'], @transform ? Models::FundingTicker.new(payload_with_sym) : payload)
       end
     end
 


### PR DESCRIPTION
This PR adds symbols to the trading & funding ticker models, mirroring the behavior of the Node.JS models. The symbol is injected into WSv2 payloads from channel data.