### PR TITLE
Fix RESTv2 initialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.7
+
+- Fixes issue with RESTv2 client initialization.
+
 1.0.6
 - Adds order affiliate code support to rest & ws v2 transports
 

--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bitfinex-rb'
-  spec.version       = '1.0.6'
+  spec.version       = '1.0.7'
   spec.authors       = ['Bitfinex']
   spec.email         = ['developers@bitfinex.com']
   spec.summary       = %q{Bitfinex API Wrapper}

--- a/lib/rest/v2.rb
+++ b/lib/rest/v2.rb
@@ -14,7 +14,7 @@ module Bitfinex
   class RESTv2
     attr_accessor :api_endpoint, :debug, :debug_connection, :api_version
     attr_accessor :rest_timeout, :rest_open_timeout, :proxy
-    attr_accessor :api_key, :api_secret
+    attr_accessor :api_key, :api_secret, :aff_code
 
     include Bitfinex::RESTClient
     include Bitfinex::RESTv2Margin


### PR DESCRIPTION
### Description:
This PR adds `attr_accessor :aff_code` to RESTv2 class.
There is the problem with RESTv2 client initializtion because of the aff_code attr_accessor missing. 

 ### Fixes:
- Fix issue with RESTv2 class initialization

 ### PR status:
- [x] Version bumped
- [x] Change-log updated
