### PR TITLE
Fix warnings from BigDecimal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.8
+
+- Fixes warning about BigDecimal.new deprecation
+
 1.0.7
 
 - Fixes issue with RESTv2 client initialization.

--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bitfinex-rb'
-  spec.version       = '1.0.7'
+  spec.version       = '1.0.8'
   spec.authors       = ['Bitfinex']
   spec.email         = ['developers@bitfinex.com']
   spec.summary       = %q{Bitfinex API Wrapper}

--- a/lib/models/funding_offer.rb
+++ b/lib/models/funding_offer.rb
@@ -38,8 +38,8 @@ module Bitfinex
         data = {
           :type => @type,
           :symbol => @symbol,
-          :amount => BigDecimal.new(@amount, 8).to_s,
-          :rate => BigDecimal.new(@rate, 8).to_s,
+          :amount => BigDecimal(@amount, 8).to_s,
+          :rate => BigDecimal(@rate, 8).to_s,
           :period => 2
         }
         if !@flags.nil?

--- a/lib/models/order.rb
+++ b/lib/models/order.rb
@@ -173,7 +173,7 @@ module Bitfinex
           :cid => cid,
           :symbol => @symbol,
           :type => @type,
-          :amount => BigDecimal.new(@amount, 8).to_s,
+          :amount => BigDecimal(@amount, 8).to_s,
           :flags => @flags || 0,
           :meta => @meta
         }
@@ -184,14 +184,14 @@ module Bitfinex
           data[:lev] = @lev
         end
 
-        data[:price] = BigDecimal.new(@price, 5).to_s if !@price.nil?
-        data[:price_trailing] = BigDecimal.new(@price_trailing, 5).to_s if !@price_trailing.nil?
+        data[:price] = BigDecimal(@price, 5).to_s if !@price.nil?
+        data[:price_trailing] = BigDecimal(@price_trailing, 5).to_s if !@price_trailing.nil?
 
         if !@price_aux_limit.nil?
           if is_oco
-            data[:price_oco_stop] = BigDecimal.new(@price_aux_limit, 5).to_s
+            data[:price_oco_stop] = BigDecimal(@price_aux_limit, 5).to_s
           else
-            data[:price_aux_limit] = BigDecimal.new(@price_aux_limit, 5).to_s
+            data[:price_aux_limit] = BigDecimal(@price_aux_limit, 5).to_s
           end
         end
 

--- a/lib/rest/v2/funding.rb
+++ b/lib/rest/v2/funding.rb
@@ -78,7 +78,7 @@ module Bitfinex
     # @return [Array] Raw notification
     ###
     def submit_funding_auto(currency, amount, period, rate='0', status=1)
-      dec_amount = BigDecimal.new(amount, 8).to_s
+      dec_amount = BigDecimal(amount, 8).to_s
       payload = { :status => status, :currency => currency, :amount => dec_amount, :period => period, :rate => rate }
       authenticated_post("auth/w/funding/auto", params: payload).body
     end


### PR DESCRIPTION
### Description:
This fixes the warning:
`warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`

 ### Fixes:
- [x] The deprecation warning about BigDecimal

 ### PR status:
- [x] Version bumped
- [x] Change-log updated

If this PR is OK, please, push new version to the RubyGems =-)