### PR TITLE
Fix stdout logging for websockets v2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.10
+
+- Fixes an issue with STDOUT logging for ws2
+
 1.0.9
 
 - Fixes bug with API v2 transfer

--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bitfinex-rb'
-  spec.version       = '1.0.9'
+  spec.version       = '1.0.10'
   spec.authors       = ['Bitfinex']
   spec.email         = ['developers@bitfinex.com']
   spec.summary       = %q{Bitfinex API Wrapper}

--- a/lib/ws/ws2.rb
+++ b/lib/ws/ws2.rb
@@ -61,8 +61,12 @@ module Bitfinex
     # @param [boolean] params.checksum_audit - enables automatic OB checksum verification (requires manage_order_books)
     ###
     def initialize (params = {})
-      @l = Logger.new(STDOUT)
-      @l.progname = 'ws2'
+      if params[:logger]
+        @l = params[:logger]
+      else
+        @l = Logger.new(STDOUT)
+        @l.progname = 'ws2'
+      end
 
       @url = params[:url] || 'wss://api.bitfinex.com/ws/2'
       @aff_code = params[:aff_code]


### PR DESCRIPTION
### Description:
In the current implementation websockest log the events to stdout. This is very inconvinient, so I added the ability to specify the logger to use.
 ### PR status:
- [ ] Version bumped
- [ ] Change-log updated
