### PR TITLE
Fix/nonce

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.0.11
+- Fixes nonce issue to be compatible with other libraries
+
 1.0.10
 - Adds function rest/v2 get_pulse_profile
 - Adds function rest/v2 get_public_pulse_history

--- a/bitfinex-rb.gemspec
+++ b/bitfinex-rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bitfinex-rb'
-  spec.version       = '1.0.10'
+  spec.version       = '1.0.11'
   spec.authors       = ['Bitfinex']
   spec.email         = ['developers@bitfinex.com']
   spec.summary       = %q{Bitfinex API Wrapper}

--- a/lib/rest/rest_client.rb
+++ b/lib/rest/rest_client.rb
@@ -89,7 +89,7 @@ module Bitfinex
     end
 
     def new_nonce
-      (Time.now.to_f * 1000).floor.to_s
+      (Time.now.to_f * 1000000).floor.to_s
     end
 
     def sign(payload)

--- a/lib/ws/ws2.rb
+++ b/lib/ws/ws2.rb
@@ -645,7 +645,7 @@ module Bitfinex
     end
 
     def new_nonce # :nodoc:
-      (Time.now.to_f * 1000).floor.to_s
+      (Time.now.to_f * 1000000).floor.to_s
     end
 
     def sign (payload) # :nodoc:


### PR DESCRIPTION
### Description:
py, rb and go timestamps return 10 char long value vs node 13.
To match node, * 1000 was added to all other libs. Someone also
added it to node lib too breaking the flow again.
py lib has it fixed by * 1000000, so adding to go and rb libs

### Fixes:
- nonce issue

### PR status:
- [x] Version bumped
- [x] Change-log updated